### PR TITLE
Make right-click menu more adaptive

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -249,8 +249,8 @@ var RightClick = RightClick || {};
                 });
             }
             else {
-                var top = event.pageY + delimiter.position().top - delimiter.offset().top + 15;
-                var left = event.pageX + delimiter.position().left - delimiter.offset().left - (div.width() / 2) - 5;
+                var top = event.pageY + delimiter.position().top - delimiter.offset().top + 5;
+                var left = event.pageX + delimiter.position().left - delimiter.offset().left - 5;
                 var arrow = (div.width() / 2);
                 var space = div.outerWidth(true) - div.innerWidth();
 
@@ -274,6 +274,10 @@ var RightClick = RightClick || {};
                     }
 
                     left = newLeft;
+                }
+
+                if (top + div.outerHeight(true) >= $(window).height()) {
+                    top -= div.outerHeight(true);
                 }
 
                 div.css({


### PR DESCRIPTION
This accounts for when the menu is being shown close to the bottom of the screen. It also moves the upper left corner a bit closer to the cursor to mimick OS context menus (and Google Drive :)

Could be cool to remove the arrow at the top too, but coudn't find an appropriate class to add