### PR TITLE
Fix WebDAV links

### DIFF
--- a/js/files.js
+++ b/js/files.js
@@ -137,7 +137,7 @@ var RightClick = RightClick || {};
             }
 
             if (text !== '') {
-                addNewOpenSubOption('WebDAV', 'public', t(appName, 'Get WebDAV link'), window.location.origin + OC.generateUrl('/remote.php/webdav') + currentFile.attr('data-path') + (currentFile.attr('data-path') === '/' ? '' : '/') + currentFile.attr('data-file'), false);
+                addNewOpenSubOption('WebDAV', 'public', t(appName, 'Get WebDAV link'), OC.linkToRemote('webdav' + currentFile.attr('data-path') + (currentFile.attr('data-path') === '/' ? '' : '/') + currentFile.attr('data-file')), false);
 
                 addNewOption('Open', icon, text, onClick, true, openSubOptions);
             }


### PR DESCRIPTION
Clicking on "Get WebDAV link" currently returns a wrong link because OC.generateUrl() adds "index.php" to the URL : https://my.nextcloud.com/index.php/remote.php/webdav/file.kdbx

The URL must be https://my.nextcloud.com/remote.php/webdav/file.kdbx instead